### PR TITLE
Swagger 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,12 @@ dependencies {
     // https://mvnrepository.com/artifact/mysql/mysql-connector-java
     implementation("mysql:mysql-connector-java:8.0.27")
 
+    // https://mvnrepository.com/artifact/io.springfox/springfox-swagger2
+    implementation("io.springfox:springfox-swagger2:2.9.2")
+
+    // https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
+    implementation("io.springfox:springfox-swagger-ui:2.9.2")
+
     // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
     compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 

--- a/app/src/main/kotlin/mapleGBP/config/SwaggerConfiguration.kt
+++ b/app/src/main/kotlin/mapleGBP/config/SwaggerConfiguration.kt
@@ -1,0 +1,39 @@
+package mapleGBP.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Controller
+import springfox.documentation.builders.ApiInfoBuilder
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2
+
+@Configuration
+@EnableSwagger2
+open class SwaggerConfiguration {
+
+    @Bean
+    open fun docket(): Docket {
+        val groupName: String = "V1"
+        return Docket(DocumentationType.SWAGGER_2)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("mapleGBP.controller"))
+            .paths(PathSelectors.any())
+            .build()
+            .groupName(groupName)
+            .pathMapping("/")
+            .apiInfo(apiInfo())
+    }
+
+    private fun apiInfo(): ApiInfo {
+        return ApiInfoBuilder()
+            .title("Boss Party Manage API")
+            .description("메이플 보스 파티 관리용 서버 API")
+            .version("v0.0.1")
+            .build()
+    }
+
+}

--- a/app/src/main/kotlin/mapleGBP/config/WebConfiguration.kt
+++ b/app/src/main/kotlin/mapleGBP/config/WebConfiguration.kt
@@ -3,10 +3,18 @@ package mapleGBP.config
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 @EnableWebMvc
 @ComponentScan(basePackages = ["mapleGBP"])
 open class WebConfiguration: WebMvcConfigurer {
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        registry.addResourceHandler("swagger-ui.html")
+            .addResourceLocations("classpath:/META-INF/resources/")
+
+        registry.addResourceHandler("/webjars/**")
+            .addResourceLocations("classpath:/META-INF/resources/webjars/")
+    }
 }

--- a/app/src/main/kotlin/mapleGBP/controller/GuildController.kt
+++ b/app/src/main/kotlin/mapleGBP/controller/GuildController.kt
@@ -1,5 +1,6 @@
 package mapleGBP.controller
 
+import io.swagger.annotations.ApiOperation
 import mapleGBP.model.World
 import mapleGBP.model.dto.GuildInfo
 import mapleGBP.service.GuildService
@@ -11,11 +12,13 @@ class GuildController(
     var guildService: GuildService
 ) {
 
+    @ApiOperation("전체 길드 조회")
     @GetMapping("/guild")
     fun getAllGuilds(): List<GuildInfo> {
         return guildService.getAllGuildInfo()
     }
 
+    @ApiOperation("길드 조회")
     @GetMapping("/guild/{world}/{guildName}")
     fun getGuild(@PathVariable("world") world: World,
                  @PathVariable("guildName") guildName: String): GuildInfo {
@@ -26,12 +29,14 @@ class GuildController(
         }
     }
 
+    @ApiOperation("길드 등록")
     @PostMapping("/guild")
     fun createGuild(@RequestBody guildInfo: GuildInfo): Boolean {
         guildService.saveGuildInfo(guildInfo)
         return true
     }
 
+    @ApiOperation("길드 멤버 정보 갱신")
     @PostMapping("/guild/{world}/{guildName}/sync")
     fun saveOrUpdateGuildMember(@PathVariable("world") world: World,
                                 @PathVariable("guildName") guildName: String): Boolean {
@@ -39,6 +44,7 @@ class GuildController(
         return true
     }
 
+    @ApiOperation("길드 삭제")
     @DeleteMapping("/guild/{world}/{guildName}")
     fun deleteGuild(@PathVariable("world") world: World,
                     @PathVariable("guildName") guildName: String): Boolean {

--- a/app/src/main/kotlin/mapleGBP/controller/PartyController.kt
+++ b/app/src/main/kotlin/mapleGBP/controller/PartyController.kt
@@ -1,5 +1,6 @@
 package mapleGBP.controller
 
+import io.swagger.annotations.ApiOperation
 import mapleGBP.model.dto.PartyInfo
 import mapleGBP.model.dto.UserInfo
 import mapleGBP.service.PartyService
@@ -10,22 +11,26 @@ class PartyController(
     var partyService: PartyService,
 ) {
 
+    @ApiOperation("전체 파티 조회")
     @GetMapping("/party")
     fun getAllParties(): List<PartyInfo> {
         return partyService.getAllPartyInfo()
     }
 
+    @ApiOperation("파티 조회")
     @GetMapping("/party/{partyName}")
     fun getParty(@PathVariable("partyName") partyName: String): PartyInfo {
         return partyService.getPartyInfo(partyName)
     }
 
+    @ApiOperation("파티 등록")
     @PostMapping("/party")
     fun createParty(@RequestBody partyInfo: PartyInfo): Boolean {
         partyService.savePartyInfo(partyInfo)
         return true
     }
 
+    @ApiOperation("파티원 추가")
     @PostMapping("/party/{partyName}/members")
     fun addPartyMember(@PathVariable("partyName") partyName: String,
                        @RequestBody newUsers: List<UserInfo>): Boolean {
@@ -33,6 +38,7 @@ class PartyController(
         return true
     }
 
+    @ApiOperation("파티원 삭제")
     @DeleteMapping("/party/{partyName}/members")
     fun removePartyMember(@PathVariable("partyName") partyName: String,
                           @RequestBody targetUsers: List<UserInfo>): Boolean {
@@ -40,6 +46,7 @@ class PartyController(
         return true
     }
 
+    @ApiOperation("파티 삭제")
     @DeleteMapping("/party/{partyName}")
     fun deleteParty(@PathVariable("partyName") partyName: String): Boolean {
         partyService.deleteParty(partyName)

--- a/app/src/main/kotlin/mapleGBP/controller/UserController.kt
+++ b/app/src/main/kotlin/mapleGBP/controller/UserController.kt
@@ -1,5 +1,6 @@
 package mapleGBP.controller
 
+import io.swagger.annotations.ApiOperation
 import mapleGBP.model.dto.UserInfo
 import mapleGBP.service.UserService
 import org.springframework.stereotype.Controller
@@ -10,11 +11,14 @@ import javax.persistence.EntityNotFoundException
 class UserController(
     var userService: UserService
 ) {
+
+    @ApiOperation("전체 유저 조회")
     @GetMapping("/user")
     fun getAllUsers(): List<UserInfo> {
         return userService.getAllUserInfo()
     }
 
+    @ApiOperation("유저 조회")
     @GetMapping("/user/{nickname}")
     fun getUser(@PathVariable("nickname") nickname: String): UserInfo {
         try {
@@ -24,12 +28,14 @@ class UserController(
         }
     }
 
+    @ApiOperation("유저 등록")
     @PostMapping("/user")
     fun createUser(@RequestBody userInfo: UserInfo): Boolean {
         userService.saveOrUpdateUserInfo(userInfo)
         return true
     }
 
+    @ApiOperation("유저 정보 업데이트")
     @PutMapping("/user/{nickname}")
     fun updateUser(@PathVariable("nickname") nickname: String,
                    @RequestBody userInfo: UserInfo): Boolean {
@@ -37,6 +43,7 @@ class UserController(
         return true
     }
 
+    @ApiOperation("유저 정보 삭제")
     @DeleteMapping("/user/{nickname}")
     fun deleteUser(@PathVariable("nickname") nickname: String): Boolean {
         userService.deleteUserInfo(nickname)


### PR DESCRIPTION
# Swagger는 2.9.2로 추가
- 3.0.0부터 Springfox-Swagger에 WebFlux지원이 추가
    - 클래스 로더에서 **org.springframework.web.context.support.GenericWebApplicationContext**가 있으면 MVC용 설정을 사용하고, **org.springframework.web.reactive.HandlerResult**가 있으면 WebFlux용 설정을 사용
- 프로젝트는 MVC 구조로 만들어져 있음
- 현재는 RestTemplate대신 WebClient를 사용하고 싶어 WebFlux 의존성이 추가된 상태
- MVC, WebFlux 의존성이 모두 추가되며, 2개의 설정이 모두 사용되어 1개의 url에 2개의 메소드가 매핑되는 상황 발생
- 따라서, WebFlux 지원이 추가되기 전 버전인 2.9.2로 추가